### PR TITLE
css: fix emotes list

### DIFF
--- a/betterdgg/betterdgg.css
+++ b/betterdgg/betterdgg.css
@@ -1,5 +1,3 @@
-
-
 .chat-emote-CallCatz, .chat-emote.bdgg-chat-emote-CallCatz {
     background-image:url('images/emoticons/CallCatz.png');
     width: 22px;
@@ -68,7 +66,7 @@
     background-image:url('images/emoticons/DESBRO.png');
     width: 27px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
 }
 
 .chat-emote.chat-emote-DESBRO, .chat-emote.bdgg-chat-emote-DESBRO.bdgg-xmas {
@@ -97,10 +95,10 @@
     margin-top: -30px;
 }
 
-.chat-emote.bdgg-chat-emote-BrainSlug {
+.chat-emote-BrainSlug, .chat-emote.bdgg-chat-emote-BrainSlug {
     width: 18px;
     height: 27px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/BrainSlug.png');
 }
 
@@ -135,14 +133,14 @@
 .chat-emote-ASLAN, .chat-emote.bdgg-chat-emote-ASLAN  {
     width: 37px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background-image:url('images/emoticons/ASLAN.png');
 }
 
 .chat-emote-DJAslan, .chat-emote.bdgg-chat-emote-DJAslan {
     width: 29px;
     height: 36px;
-    margin-top: -36px !important;
+    margin-top: -36px;
     background-image:url('images/emoticons/DJAslan.png');
 }
 
@@ -161,17 +159,17 @@
     background: url('images/emoticons/Klappa.png') !important;
 }
 
-.chat-emote.bdgg-chat-emote-CARBUCKS {
+.chat-emote-CARBUCKS, .chat-emote.bdgg-chat-emote-CARBUCKS {
     width: 30px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/CARBUCKS.png');
 }
 
-.chat-emote.bdgg-chat-emote-ChanChamp {
+.chat-emote-ChanChamp, .chat-emote.bdgg-chat-emote-ChanChamp {
     width: 23px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/ChanChamp.png');
 }
 
@@ -182,80 +180,80 @@
     background: url('images/emoticons/CheekerZ.png');
 }
 
-.chat-emote.bdgg-chat-emote-Depresstiny {
+.chat-emote-Depresstiny, .chat-emote.bdgg-chat-emote-Depresstiny {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/Depresstiny.png');
 }
 
-.chat-emote.bdgg-chat-emote-HerbPerve {
+.chat-emote-HerbPerve, .chat-emote.bdgg-chat-emote-HerbPerve {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/HerbPerve.png');
 }
 
-.chat-emote.bdgg-chat-emote-Jewstiny {
+.chat-emote-Jewstiny, .chat-emote.bdgg-chat-emote-Jewstiny {
     width: 27px;
     height: 32px;
-    margin-top: -32px !important;
+    margin-top: -32px;
     background: url('images/emoticons/Jewstiny.png');
 }
 
-.chat-emote.bdgg-chat-emote-NiceMeMe {
+.chat-emote-NiceMeMe, .chat-emote.bdgg-chat-emote-NiceMeMe {
     width: 27px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/NiceMeMe.png');
 }
 
-.chat-emote.bdgg-chat-emote-CallHafu {
+.chat-emote-CallHafu, .chat-emote.bdgg-chat-emote-CallHafu {
     width: 36px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/CallHafu.png');
 }
 
-.chat-emote.bdgg-chat-emote-ChibiDesti {
+.chat-emote-ChibiDesti, .chat-emote.bdgg-chat-emote-ChibiDesti {
     width: 40px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/ChibiDesti.png');
 }
 
-.chat-emote.bdgg-chat-emote-CORAL {
+.chat-emote-CORAL, .chat-emote.bdgg-chat-emote-CORAL {
     width: 25px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/CORAL.png');
 }
 
-.chat-emote.bdgg-chat-emote-CUX {
+.chat-emote-CUX, .chat-emote.bdgg-chat-emote-CUX {
     width: 76px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/CUX.png');
 }
 
-.chat-emote.bdgg-chat-emote-DSPstiny {
+.chat-emote-DSPstiny, .chat-emote.bdgg-chat-emote-DSPstiny {
     width: 22px;
     height: 32px;
-    margin-top: -32px !important;
+    margin-top: -32px;
     background: url('images/emoticons/DSPstiny.png');
 }
 
-.chat-emote.bdgg-chat-emote-GabeN {
+.chat-emote-GabeN, .chat-emote.bdgg-chat-emote-GabeN {
     width: 27px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/GabeN.png');
 }
 
-.chat-emote.bdgg-chat-emote-ITSRAWWW {
+.chat-emote-ITSRAWWW, .chat-emote.bdgg-chat-emote-ITSRAWWW {
     width: 25px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/ITSRAWWW.png');
 }
 
@@ -266,73 +264,73 @@
     background: url('images/emoticons/PEPE.png');
 }
 
-.chat-emote.bdgg-chat-emote-POTATO {
+.chat-emote-POTATO, .chat-emote.bdgg-chat-emote-POTATO {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/POTATO.png');
 }
 
-.chat-emote.bdgg-chat-emote-RaveDoge {
+.chat-emote-RaveDoge, .chat-emote.bdgg-chat-emote-RaveDoge {
     width: 44px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/RaveDoge.gif');
 }
 
-.chat-emote.bdgg-chat-emote-CuckCrab {
+.chat-emote-CuckCrab, .chat-emote.bdgg-chat-emote-CuckCrab {
     width: 32px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/CuckCrab.gif');
 }
 
-.chat-emote.bdgg-chat-emote-Riperino {
+.chat-emote-Riperino, .chat-emote.bdgg-chat-emote-Riperino {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/Riperino.png');
 }
 
-.chat-emote.bdgg-chat-emote-SephURR {
+.chat-emote-SephURR, .chat-emote.bdgg-chat-emote-SephURR {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/SephURR.png');
 }
 
-.chat-emote.bdgg-chat-emote-ShibeZ {
+.chat-emote-ShibeZ, .chat-emote.bdgg-chat-emote-ShibeZ {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/ShibeZ.png');
 }
 
-.chat-emote.bdgg-chat-emote-SourPls {
+.chat-emote-SourPls, .chat-emote.bdgg-chat-emote-SourPls {
     width: 32px;
     height: 32px;
-    margin-top: -32px !important;
+    margin-top: -32px;
     background: url('images/emoticons/SourPls.gif');
 }
 
-.chat-emote.bdgg-chat-emote-SuccesS {
+.chat-emote-SuccesS, .chat-emote.bdgg-chat-emote-SuccesS {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/SuccesS.png');
 }
 
-.chat-emote.bdgg-chat-emote-TopCake {
+.chat-emote-TopCake, .chat-emote.bdgg-chat-emote-TopCake {
     width: 30px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/TopCake.png');
 }
 
-.chat-emote.bdgg-chat-emote-WEOW {
+.chat-emote-WEOW, .chat-emote.bdgg-chat-emote-WEOW {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/WEOW.png');
 }
 
@@ -343,143 +341,143 @@
     background: url('images/emoticons/YEE.png');
 }
 
-.chat-emote.bdgg-chat-emote-4Head {
+.chat-emote-4Head, .chat-emote.bdgg-chat-emote-4Head {
     width: 20px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/emoticons.png') no-repeat -242px -123px;
 }
 
-.chat-emote.bdgg-chat-emote-AlisherZ {
+.chat-emote-AlisherZ, .chat-emote.bdgg-chat-emote-AlisherZ {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/AlisherZ.png');
 }
 
-.chat-emote.bdgg-chat-emote-BabyRage {
+.chat-emote-BabyRage, .chat-emote.bdgg-chat-emote-BabyRage {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/BabyRage.png');
 }
 
-.chat-emote.bdgg-chat-emote-D_ {
+.chat-emote-D\:, .chat-emote.bdgg-chat-emote-D_ {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/D_.png');
 }
 
-.chat-emote.bdgg-chat-emote-DansGame {
+.chat-emote-DansGame, .chat-emote.bdgg-chat-emote-DansGame {
     width: 24px;
     height: 31px;
-    margin-top: -31px !important;
+    margin-top: -31px;
     background: url('images/emoticons/DansGame.png');
 }
 
-.chat-emote.bdgg-chat-emote-dayJoy {
+.chat-emote-dayJoy, .chat-emote.bdgg-chat-emote-dayJoy {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/dayJoy.png');
 }
 
-.chat-emote.bdgg-chat-emote-DatSheffy {
+.chat-emote-DatSheffy, .chat-emote.bdgg-chat-emote-DatSheffy {
     width: 24px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/emoticons.png') no-repeat -131px -90px;
 }
 
-.chat-emote.bdgg-chat-emote-EleGiggle {
+.chat-emote-EleGiggle, .chat-emote.bdgg-chat-emote-EleGiggle {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/EleGiggle.png');
 }
 
-.chat-emote.bdgg-chat-emote-kaceyFace {
+.chat-emote-kaceyFace, .chat-emote.bdgg-chat-emote-kaceyFace {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/kaceyFace.png');
 }
 
-.chat-emote.bdgg-chat-emote-Keepo {
+.chat-emote-Keepo, .chat-emote.bdgg-chat-emote-Keepo {
     width: 27px;
     height: 29px;
-    margin-top: -29px !important;
+    margin-top: -29px;
     background: url('images/emoticons/Keepo.png');
 }
 
-.chat-emote.bdgg-chat-emote-Kreygasm {
+.chat-emote-Kreygasm, .chat-emote.bdgg-chat-emote-Kreygasm {
     width: 19px;
     height: 27px;
-    margin-top: -27px !important;
+    margin-top: -27px;
     background: url('images/emoticons/emoticons.png') no-repeat -141px 0;
 }
 
-.chat-emote.bdgg-chat-emote-lirikThump {
+.chat-emote-lirikThump, .chat-emote.bdgg-chat-emote-lirikThump {
     width: 28px;
     height: 26px;
-    margin-top: -26px !important;
+    margin-top: -26px;
     background: url('images/emoticons/lirikThump.png');
 }
 
-.chat-emote.bdgg-chat-emote-OpieOP {
+.chat-emote-OpieOP, .chat-emote.bdgg-chat-emote-OpieOP {
     width: 21px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/emoticons.png') no-repeat -179px -123px;
 }
 
-.chat-emote.bdgg-chat-emote-PJSalt {
+.chat-emote-PJSalt, .chat-emote.bdgg-chat-emote-PJSalt {
     width: 36px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/emoticons.png') no-repeat -106px -123px;
 }
 
-.chat-emote.bdgg-chat-emote-PogChamp {
+.chat-emote-PogChamp, .chat-emote.bdgg-chat-emote-PogChamp {
     width: 23px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/emoticons.png') no-repeat -166px -28px;
 }
 
-.chat-emote.bdgg-chat-emote-ResidentSleeper {
+.chat-emote-ResidentSleeper, .chat-emote.bdgg-chat-emote-ResidentSleeper {
     width: 28px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/emoticons.png') no-repeat -212px -28px;
 }
 
-.chat-emote.bdgg-chat-emote-SMOrc {
+.chat-emote-SMOrc, .chat-emote.bdgg-chat-emote-SMOrc {
     width: 32px;
     height: 32px;
-    margin-top: -32px !important;
+    margin-top: -32px;
     background: url('images/emoticons/emoticons.png') no-repeat -25px -123px;
 }
 
-.chat-emote.bdgg-chat-emote-SSSsss {
+.chat-emote-SSSsss, .chat-emote.bdgg-chat-emote-SSSsss {
     width: 24px;
     height: 24px;
-    margin-top: -24px !important;
+    margin-top: -24px;
     background: url('images/emoticons/emoticons.png') no-repeat -239px 0;
 }
 
-.chat-emote.bdgg-chat-emote-SwiftRage {
+.chat-emote-SwiftRage, .chat-emote.bdgg-chat-emote-SwiftRage {
     width: 21px;
     height: 28px;
-    margin-top: -28px !important;
+    margin-top: -28px;
     background: url('images/emoticons/emoticons.png') no-repeat -241px -28px;
 }
 
-.chat-emote.bdgg-chat-emote-WinWaker {
+.chat-emote-WinWaker, .chat-emote.bdgg-chat-emote-WinWaker {
     width: 30px;
     height: 30px;
-    margin-top: -30px !important;
+    margin-top: -30px;
     background: url('images/emoticons/emoticons.png') no-repeat -23px -59px;
 }
 


### PR DESCRIPTION
This patch fixes both emotes appearing "above" their space in the emotes list (i.e. ![](https://cdn.rawgit.com/destinygg/website/cd991c81b81a8f8b2374bb400c7583ad379ce32b/scripts/emotes/emoticons/ASLAN.png)) and emotes not appearing at all (i.e. most bbdgg emotes).
## before

![](https://i.imgur.com/VWMeiIn.png)
## after

![](https://i.imgur.com/fZXSmE1.png)

Despite this patch, these emotes still display as a blank space on the list:
- `OuO` (text emote)
- `XD` (text emote)
- `nathanEww` (not an actual emote?)

Text emotes might require a more creative solution (i.e. having an image take their spot in the list).
