### PR TITLE
css: invert colors of NOBULLY on hover

### DIFF
--- a/betterdgg/betterdgg.css
+++ b/betterdgg/betterdgg.css
@@ -19,6 +19,11 @@
     margin-top: -30px;
 }
 
+.chat-emote-NOBULLY:hover, .bdgg-chat-emote-NOBULLY:hover {
+    -webkit-filter: invert(100%);
+    filter: invert(100%);
+}
+
 .chat-emote-gachiGASM, .chat-emote.bdgg-chat-emote-gachiGASM {
     background-image:url('images/emoticons/gachiGASM.png');
     width: 30px;


### PR DESCRIPTION
Requested by PurpleCow

```
[2016-03-10 16:54:11 UTC] PurpleCow: downthecrop What if the NOBULLY emote turned to a BULLY version when you moused over it WhoahDude
```

This inverts the colors of `NOBULLY` on hover.

I don't know if anyone else wants it; nor if it is a good idea at all. But since it's so easy to implement I just figured I might as well send a PR and see how it goes. We could also have it slowly invert instead of doing so instantaneously, just let me know.
