### PR TITLE
make forms match destiny.gg style

### DIFF
--- a/betterdgg/betterdgg.css
+++ b/betterdgg/betterdgg.css
@@ -611,6 +611,7 @@
 
 .bdgg-menu label {
     font-weight: normal !important;
+    width: 100%;
 }
 
 .bdgg-menu label:hover {

--- a/betterdgg/templates/menu_text.jade
+++ b/betterdgg/templates/menu_text.jade
@@ -1,4 +1,5 @@
 li
   label.text(title=setting.description)
     = setting.name
-    input(id=setting.key type="text" title=setting.description, value=setting.value)
+    input.form-control.input-sm(id=setting.key type="text"
+      title=setting.description, value=setting.value)


### PR DESCRIPTION
Another CSS thing.

I don't know about anyone else, but when I was trying to add users to the new passive stalk feature I noticed that the color of the font would become white when the input form was active. Since the input background is also white, this makes it impossible to read the text:

![bbdgg-bad-form](https://cloud.githubusercontent.com/assets/733364/13730524/31ad573a-e928-11e5-8306-feb20a119b69.gif)

This patch fixes this by applying the same style already used for the "Custom highlight words" setting in vanilla destiny.gg:

![2016-03-13-14-26-52-0346330](https://cloud.githubusercontent.com/assets/733364/13730533/5590b516-e928-11e5-85e4-eaefc333162c.png)
