### PR TITLE
build firefox xpi with jpm

### DIFF
--- a/firefox/lib/window-listener.js
+++ b/firefox/lib/window-listener.js
@@ -11,7 +11,7 @@ const { Cc, Ci } = require("chrome");
 const wm = Cc["@mozilla.org/appshell/window-mediator;1"].
            getService(Ci.nsIWindowMediator);
 
-const { pagemod, workerAttached } = require("service");
+const { pagemod, workerAttached } = require("./service");
 
 var windowListener = {
     //DO NOT EDIT HERE

--- a/firefox/package.json
+++ b/firefox/package.json
@@ -13,5 +13,6 @@
       "http://downthecrop.xyz",
       "http://api.overrustle.com"
     ]
-  }
+  },
+  "main": "lib/main.js"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,9 +155,7 @@ gulp.task('firefox', [ 'firefox:css', 'firefox:manifest', 'js' ], function() {
 });
 
 gulp.task('firefox:xpi', [ 'firefox' ], function() {
-    run('mkdir -p ./dist && cd ./build/firefox && cfx xpi'
-    + ' --update-url https://downthecrop.xyz/bbdgg/firefox/update.rdf'
-        + ' --output-file=../../dist/betterdgg.xpi').exec();
+    run('mkdir -p ./dist && cd ./build/firefox && jpm xpi').exec();
 });
 
 gulp.task('safari:plist', function() {


### PR DESCRIPTION
tentative todo:
- [X] ~~document need to have `jpm` installed~~ the "Mozilla Add-on SDK" link already points to `jpm` installation
- [ ] add `firefox:sign` gulp task to run `jpm sign` (API keys required; can either be environment variables or in a config file that we don't add to git)
