### PR TITLE
Private message desktop notifications

### DIFF
--- a/betterdgg/modules/notification.js
+++ b/betterdgg/modules/notification.js
@@ -1,0 +1,36 @@
+;(function(bdgg) {
+	bdgg.notification = (function() {
+		return {
+			init: function() {
+				var isChrome
+				isChrome = !!window.chrome && !!window.chrome.webstore
+				var fnChatPRIVMSG = destiny.chat.onPRIVMSG
+				var bdggChatPRIVMSG = function(data) {
+					var bdggPRIVMSG = fnChatPRIVMSG.apply(this, arguments);
+					var notif
+					var isChrome = !!window.chrome && !!window.chrome.webstore
+					if (bdgg.settings.get('bdgg_Private_Message_Notifications')) {
+						if (Notification.permission === 'granted' && isChrome){
+							var memes = {
+								body: data.nick + " sent you a private message, Click me to view the chat!",
+								icon: destiny.cdn + '/chat/img/notifyicon.png'
+							}
+							notif = new Notification("Better Better Destiny.GG", memes)
+							notif.onclick = function(x) { window.focus(); notif.close(); };
+							setTimeout(function(){ notif.close(); }, 5000)
+						} else if (Notification.permission === 'granted' && !isChrome){
+							var memes = {
+								body: data.nick + " sent you a private message, Click me to view the chat!",
+								icon: destiny.cdn + '/chat/img/notifyicon.png'
+							}
+							notif = new Notification("Better Better Destiny.GG", memes)
+							setTimeout(function(){ notif.close(); }, 5000)
+						}
+					}
+					return bdggPRIVMSG;
+				}
+				destiny.chat.onPRIVMSG = bdggChatPRIVMSG;
+			}
+		}
+	})()
+}(window.BetterDGG = window.BetterDGG || {}))

--- a/betterdgg/modules/settings.js
+++ b/betterdgg/modules/settings.js
@@ -84,6 +84,13 @@
             'type': 'boolean'
         },
 
+        'bdgg_Private_Message_Notifications': {
+            'name': "Private message desktop notifications",
+            'description': "Show desktop notifications on receipt of a private message",
+            'value': true,
+            'type': 'boolean'
+        },
+
         'bgg_passive_stalk': {
             'name': 'Passive stalk targets',
             'description': 'Sweetie_Belle\'s passive stalk highlighting',


### PR DESCRIPTION
For them times where you just can't be fucked to use your eyes. There is a working setting to turn it on and off. the "Click me" part wont show on non chrome browsers because they either have it blocked or not implemented.(Looking at you firefox you peice of shit)

Notifications have the same timer to stay on screen as the d.gg highlight notifications and the same icon, the username of the message sender will show in the message text.

**_Better Better Destiny.GG_**
**Username sent you a private message!**

It seems that chrome is also going to be implementing the new notification spec stuff such as sound and vibration(for mobile) while it has added the requires attention notification type in chrome 50, could lob some of that in just to piss people off PEPE.
