### PR TITLE
only run within embedded chat

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -24,7 +24,7 @@
 
     "content_scripts": [
         {
-            "matches": ["*://*.destiny.gg/*"],
+            "matches": ["*://*.destiny.gg/embed/chat*"],
             "css": ["betterdgg.css"],
             "js": ["betterdgg.js","lib/panscroll.js"],
             "all_frames":true

--- a/firefox/lib/service.js
+++ b/firefox/lib/service.js
@@ -26,7 +26,7 @@ var workerAttached = function(worker) {
 };
 
 var mod = pageMod.PageMod({
-    include: "*.destiny.gg",
+    include: /.*destiny\.gg\/embed\/chat.*/,
     contentScriptFile: data.url("betterdgg.js"),
     contentStyleFile: [ data.url("betterdgg.css") ],
     attachTo: [ "top", "frame" ],


### PR DESCRIPTION
Before this patch, the extension was running twice on /bigscreen: once on the bigscreen page itself and again in the embedded chat `iframe`. The instance on the bigscreen page just errors out because `destiny.chat` is `undefined`, but the instance in the `iframe` continues working normally which is probably how this was never noticed.
