### PR TITLE
load settings module first

### DIFF
--- a/betterdgg/betterdgg.js
+++ b/betterdgg/betterdgg.js
@@ -1,11 +1,13 @@
+// load settings module before everything else
+window.BetterDGG.settings.init();
+
 for (var module in window.BetterDGG) {
-    if (window.BetterDGG[module].init) {
+    if (module !== 'settings' && window.BetterDGG[module].init) {
         try {
             window.BetterDGG[module].init();
         }
         catch (e) {
             console.log(e)
-            
         }
     }
 }


### PR DESCRIPTION
Fixes a race condition wherein on some page loads, other modules will load and try to get settings before the settings module has loaded.
