### PR TITLE
enforce usage of strict equality

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@ rules:
   semi: 2
   no-cond-assign: 0
   indent: 2
+  eqeqeq: ["error", "allow-null"]
 
 globals:
   # stuff defined on destiny.gg

--- a/betterdgg/content-scripts/content.js
+++ b/betterdgg/content-scripts/content.js
@@ -1,9 +1,11 @@
 function isWindow(src) {
-    return src == window || typeof unsafeWindow != "undefined" && src.wrappedJSObject == unsafeWindow;
+    return src === window
+        || typeof unsafeWindow !== "undefined"
+        && src.wrappedJSObject === unsafeWindow;
 }
 
 function doXHR(xhr) {
-    if (typeof chrome != "undefined" && chrome.runtime) {
+    if (typeof chrome !== "undefined" && chrome.runtime) {
         chrome.runtime.sendMessage(null, { xhr: xhr }, xhr.onload);
     } else {
         var req = new XMLHttpRequest();
@@ -21,9 +23,9 @@ window.addEventListener("message", function(e) {
 
     var xhr;
 
-    if (e.data.type == 'bdgg_hello_world') {
+    if (e.data.type === 'bdgg_hello_world') {
         console.warn("Content script received: " + e.data.text);
-    } else if (e.data.type == 'bdgg_ustream_url') {
+    } else if (e.data.type === 'bdgg_ustream_url') {
         xhr = {
             onload: function(responseText) {
                 var match;
@@ -36,7 +38,7 @@ window.addEventListener("message", function(e) {
             url: e.data.text
         };
         doXHR(xhr);
-    } else if (e.data.type == 'bdgg_overrustle_get_strims') {
+    } else if (e.data.type === 'bdgg_overrustle_get_strims') {
         xhr = {
             onload: function(responseText) {
                 var strims = parseStrims(responseText);
@@ -46,7 +48,7 @@ window.addEventListener("message", function(e) {
             url: 'http://api.overrustle.com/api'
         };
         doXHR(xhr);
-    } else if (e.data.type == 'bdgg_get_profile_info') {
+    } else if (e.data.type === 'bdgg_get_profile_info') {
         xhr = {
             onload: function(responseText) {
                 var info = JSON.parse(responseText);
@@ -71,7 +73,7 @@ function parseStrims(responseText) {
         return buildStrim(resp, k, enrich);
     }).sort(function(a, b) {
         // most to least or alphabetical
-        if (a.viewers != b.viewers) {
+        if (a.viewers !== b.viewers) {
             return b.viewers - a.viewers;
         }
 

--- a/betterdgg/content-scripts/stalk.js
+++ b/betterdgg/content-scripts/stalk.js
@@ -1,9 +1,9 @@
 var port = null;
 
-if (typeof chrome != "undefined" && chrome.runtime) {
+if (typeof chrome !== "undefined" && chrome.runtime) {
     port = chrome.runtime.connect();
     port.onMessage.addListener(pushMessage);
-} else if (typeof self != "undefined" && self.postMessage) {
+} else if (typeof self !== "undefined" && self.postMessage) {
     self.on("message", pushMessage);
 }
 
@@ -12,13 +12,13 @@ window.addEventListener("message", function(e) {
         return;
     }
 
-    if (e.data.type == 'bdgg_stalk_request') {
+    if (e.data.type === 'bdgg_stalk_request') {
         // Copy data for firefox to work
         portMessage({ data: e.data });
-    } else if (e.data.type == 'bdgg_flair_update') {
+    } else if (e.data.type === 'bdgg_flair_update') {
         //console.log("Flair update received: " + e.data);
         portMessage({ data: e.data });
-    } else if (e.data.type == 'bdgg_users_refresh') {
+    } else if (e.data.type === 'bdgg_users_refresh') {
         //console.log("Refresh users");
         portMessage({ data: e.data });
     }
@@ -31,9 +31,9 @@ function pushMessage(obj)
 
 function portMessage(obj)
 {
-    if (typeof chrome != "undefined" && chrome.runtime) {
+    if (typeof chrome !== "undefined" && chrome.runtime) {
         port.postMessage(obj);
-    } else if (typeof self != "undefined" && self.postMessage) {
+    } else if (typeof self !== "undefined" && self.postMessage) {
         self.postMessage(obj);
     }
 }

--- a/betterdgg/modules/leftchat.js
+++ b/betterdgg/modules/leftchat.js
@@ -10,7 +10,7 @@
                     bdgg.left.leftBoys(bdgg.settings.get('bdgg_left_chat'));
                     bdgg.left.resizeTakeOver();
                     bdgg.settings.addObserver(function(key, val) {
-                        if (key == 'bdgg_left_chat')
+                        if (key === 'bdgg_left_chat')
                             bdgg.left.leftBoys(val);
                     });
                 }

--- a/betterdgg/modules/overrustle.js
+++ b/betterdgg/modules/overrustle.js
@@ -26,7 +26,7 @@
         };
 
         var listener = function(e) {
-            if (window != e.source || e.data.type != 'bdgg_overrustle_strims' ) {
+            if (window !== e.source || e.data.type !== 'bdgg_overrustle_strims') {
                 return;
             }
 
@@ -79,9 +79,9 @@
 
         BDGGChatStrimMessage.prototype.icon = function() {
             var ico = "icon-bdgg-play";
-            if (this.platform == 'twitch') {
+            if (this.platform === 'twitch') {
                 ico = "icon-bdgg-platform-twitch";
-            } else if (this.platform == 'ustream') {
+            } else if (this.platform === 'ustream') {
                 ico = "icon-bdgg-platform-ustream";
             }
 
@@ -127,8 +127,9 @@
                 elem.id = elemId;
 
                 var listener = function(e) {
-                    if (window != e.source ||
-                            e.data.type != 'bdgg_ustream_channel' || e.data.text != href) {
+                    if (window !== e.source
+                        || e.data.type !== 'bdgg_ustream_channel'
+                        || e.data.text !== href) {
                         return;
                     }
 
@@ -162,7 +163,7 @@
             init: function() {
                 bdgg.overrustle.convertLinks(bdgg.settings.get('bdgg_convert_overrustle_links'));
                 bdgg.settings.addObserver(function(key, value) {
-                    if (key == 'bdgg_convert_overrustle_links') {
+                    if (key === 'bdgg_convert_overrustle_links') {
                         bdgg.overrustle.convertLinks(value);
                     }
                 });

--- a/betterdgg/modules/settings.js
+++ b/betterdgg/modules/settings.js
@@ -178,7 +178,7 @@
                 $('#bdgg-settings-btn').removeClass('active');
             },
             add: function(setting) {
-                if (setting.type == 'string') {
+                if (setting.type === 'string') {
                     $('#bdgg-advanced ul').append(bdgg.templates.advanced_text({setting: setting}));
                     $('#bdgg-advanced input[type="text"]#' + setting.key).on('blur', function() {
                         var value = $(this).val();
@@ -197,7 +197,7 @@
                 if (value == null) {
                     value = defValue;
                     bdgg.settings.put(key, defValue);
-                } else if (SETTINGS[key] && SETTINGS[key].type == 'boolean') {
+                } else if (SETTINGS[key] && SETTINGS[key].type === 'boolean') {
                     value = value === 'true';
                 }
 

--- a/betterdgg/modules/stalk.js
+++ b/betterdgg/modules/stalk.js
@@ -150,11 +150,11 @@
                 };
 
                 var listener = function(e) {
-                    if (window != e.source) {
+                    if (window !== e.source) {
                         return;
                     }
 
-                    if (e.data.type == 'bdgg_stalk_reply') {
+                    if (e.data.type === 'bdgg_stalk_reply') {
                         var reply = e.data.reply;
 
                         if (reply.Type === "s") {
@@ -167,9 +167,9 @@
                         else if (reply.Type === "e") {
                             PushError("Error: " + reply.Error);
                         }
-                    } else if (e.data.type == 'bdgg_stalk_message') {
+                    } else if (e.data.type === 'bdgg_stalk_message') {
                         PushChat(e.data.message);
-                    } else if (e.data.type == 'bdgg_stalk_error') {
+                    } else if (e.data.type === 'bdgg_stalk_error') {
                         PushError(e.data.error);
                     }
                 };
@@ -192,7 +192,7 @@
 
                         if (nickCount < 1) {
                             return;
-                        } else if (nickCount == 1) {
+                        } else if (nickCount === 1) {
                             // Stalk
                             querystr["QueryType"] = "s";
                             querystr["Name"] = match[1];


### PR DESCRIPTION
I don't know why I said https://github.com/BryceMatthes/betterdgg/pull/29 enforced strict equality when it actually didn't.

For now, I'm allowing the use of `!= null` (through a configuration of this `eqeqeq` rule) since it can be used to check for `null` and `undefined` at once. I'll get rid of it in a later PR.

``` js
null == undefined
// => true

null === undefined
// => false
```
