### PR TITLE
New phrases feature

### DIFF
--- a/betterdgg/modules/phrases.js
+++ b/betterdgg/modules/phrases.js
@@ -2,24 +2,49 @@
     bdgg.phrases = (function() {
 
         var PHRASES = [ 
+            //old phrases
             /(^|\b)BAR($|\b)/, 
+            /.*?twitter\.com\/antibullyranger.*?/,
+
+            //from addmute or addban
+            /used my safeword/,
+            /just can't nod and smile/,
+            /(^|\s)momo\s.*\sbanned($|\s)|(^|\s)momo banned($|\s)/,
+            /([\s\S]+?)?play([\s\S]+?)?undertale([\s\S]+?)?/,
+            /([\s\S]+?)?dest[il]ny([\s\S]+?)?underta[il]e([\s\S]+?)?/,
+            /!logs Eschkapade/,
+            /\/scyx/,
+            /卐/,
+            /\/r\/bliutwo/,
+            /\/ScYx17/,
+
+            //links
+            /puu\.sh\/iHbP6/, //knock knock
+            /OSCiMbMVDLI/, //wake me up
+            /SUdVyW0tcSo/, //wake me up
+            /dQw4w9WgXcQ/, //rick
+            /puu\.sh\/k0Hki\.jpg/, //knock knock
+            /twitter\.com\/steven__bonnell/,
+            /twitter\.com\/Sc2Destiny/,
+            /tinyurl\.com/,
+
+            //for debugging
             /(^|\b)JUSTATEST($|\b)/
         ];
 
-        function _testPhrase(phrases, line) {
-
-            var abort = false;
+        function _checkMessage(phrases, line) {
 
             for (var i = 0; i < phrases.length; i++) {
-                phraseMatches = line.match(phrases[i]);
+                var phraseMatches = line.match(phrases[i]);
                 if (phraseMatches){
-                        abort = true;
+                    return phrases[i]; //return whatever the message matched so we can give feedback
                 }
             }
 
-            return abort;
+            //no match found, message seems good.
+            return false;
         }
-    
+
         return {
             init: function() {
 
@@ -27,9 +52,12 @@
                 destiny.chat.gui.send = function() {
 
                     if (bdgg.settings.get('bdgg_prohibited_phrase_filter')){
-                        var msg = destiny.chat.gui.input.val()
+                        var message = destiny.chat.gui.input.val();
+                        var blackListMatch = _checkMessage(PHRASES, message);
                         //If the content of the chat input box matches any prohibited phrase, do not call the send function.
-                        if (_testPhrase(PHRASES, msg)) {
+                        if (blackListMatch) {
+                            var errorMessage = new ChatErrorMessage("BBDGG prevented your message from being sent because it matched the following prohibited phrase: " + blackListMatch.toString());
+                            destiny.chat.gui.push(errorMessage);
                             return;
                         }
                     }

--- a/betterdgg/modules/phrases.js
+++ b/betterdgg/modules/phrases.js
@@ -1,0 +1,42 @@
+(function(bdgg) {
+    bdgg.phrases = (function() {
+
+        var PHRASES = [ 
+            /(^|\b)BAR($|\b)/, 
+            /(^|\b)JUSTATEST($|\b)/
+        ];
+
+        function _testPhrase(phrases, line) {
+
+            var abort = false;
+
+            for (var i = 0; i < phrases.length; i++) {
+                phraseMatches = line.match(phrases[i]);
+                if (phraseMatches){
+                        abort = true;
+                }
+            }
+
+            return abort;
+        }
+    
+        return {
+            init: function() {
+
+                var fnSendCommand = destiny.chat.gui.send;
+                destiny.chat.gui.send = function() {
+
+                    if (bdgg.settings.get('bdgg_prohibited_phrase_filter')){
+                        var msg = destiny.chat.gui.input.val()
+                        //If the content of the chat input box matches any prohibited phrase, do not call the send function.
+                        if (_testPhrase(PHRASES, msg)) {
+                            return;
+                        }
+                    }
+
+                    return fnSendCommand.apply(this);
+                };
+            }
+        };
+    })();
+}(window.BetterDGG = window.BetterDGG || {}));

--- a/betterdgg/modules/settings.js
+++ b/betterdgg/modules/settings.js
@@ -110,7 +110,15 @@
             'description': 'Comma-separated list of words to filter messages from chat (case-insensitive)',
             'value': '',
             'type': 'string'
+        },
+
+        'bdgg_prohibited_phrase_filter': {
+            'name': 'Avoid prohibited phrases',
+            'description': 'Issue a warning when trying to post a known prohibited phrase (Do NOT rely on this, the list is not complete)',
+            'value': true,
+            'type': 'boolean'
         }
+
     };
 
     bdgg.settings = (function() {


### PR DESCRIPTION
Prevents users from sending messages that match a given regex

This is just a basic 'proof of concept' implementation, the actual list of bad phrases has to be added yet. The handling should also be improved - right now the message just stays in the chat input box with no additional feedback.
