### PR TITLE
Fix ignore module loading issue

### DIFF
--- a/betterdgg/modules/ignore.js
+++ b/betterdgg/modules/ignore.js
@@ -34,7 +34,17 @@
             },
 
             chatLines: function() {
-                var setting = JSON.parse(localStorage.getItem('chatoptions'));
+
+                var chatoptions = localStorage.getItem('chatoptions');
+                if (chatoptions === null){
+                    /**
+                     * If the user never changed any destiny.gg settings, the options are null.
+                     * Work around this by setting it to an empty JSON string which we can opperate on.
+                     */
+                    chatoptions = "{}";
+                }
+
+                var setting = JSON.parse(chatoptions);
                 if (setting.maxlines) {
                     if (setting.maxlines < 200) {
                         setting.maxlines = 600;


### PR DESCRIPTION
At the moment we get an error because chatoptions might be null if the user never changed any "legacy" destiny.gg options before installing the addon.
Also note, if something goes wrong with setting the chatoptions (giving it an incorrect JSON string), chat does not load at all, so be careful.
