### PR TITLE
add option to highlight mentions of selected user

### DIFF
--- a/betterdgg/modules/mentions.js
+++ b/betterdgg/modules/mentions.js
@@ -1,0 +1,18 @@
+(function(bdgg) {
+    bdgg.mentions = (function() {
+        return {
+            init: function() {
+                var gui = window.destiny.chat.gui;
+
+                gui.lines.on('mousedown', 'div.user-msg a.user', function() {
+                    if (bdgg.settings.get('bdgg_highlight_selected_mentions')) {
+                        var username = $(this).text();
+                        gui.lines.find(':contains(' + username + ')').addClass('focused');
+                    }
+
+                    return false;
+                });
+            }
+        };
+    })();
+}(window.BetterDGG = window.BetterDGG || {}));

--- a/betterdgg/modules/settings.js
+++ b/betterdgg/modules/settings.js
@@ -117,8 +117,14 @@
             'description': 'Issue a warning when trying to post a known prohibited phrase (Do NOT rely on this, the list is not complete)',
             'value': true,
             'type': 'boolean'
-        }
+        },
 
+        'bdgg_highlight_selected_mentions': {
+            'name': 'Highlight mentions of selected user',
+            'description': 'Clicking a username will highlight the user\'s mentions as well as their own messages',
+            'value': false,
+            'type': 'boolean'
+        }
     };
 
     bdgg.settings = (function() {


### PR DESCRIPTION
Usually, when clicking a username, all of the messages of that user are highlighted. As requested by a few chatters, this implements a new option (disabled by default, in the interest of not changing existing behavior too much) which will also highlight the user's mentions.

Closes https://github.com/BryceMatthes/betterdgg/issues/42
