### PR TITLE
Don't show PM notif if user is ignored

### DIFF
--- a/betterdgg/modules/notification.js
+++ b/betterdgg/modules/notification.js
@@ -11,24 +11,35 @@
                 });
                 var fnChatPRIVMSG = destiny.chat.onPRIVMSG;
                 var bdggChatPRIVMSG = function(data) {
+                    var ignoreList = bdgg.settings.get('bdgg_user_ignore');
+                    var ignoreArray = ignoreList.toLowerCase().split(' ').join('').split(',');
+                    console.error(ignoreList);
+                    console.error(ignoreArray);
+
+
+
                     var bdggPRIVMSG = fnChatPRIVMSG.apply(this, arguments);
                     var notif;
-                    if (bdgg.settings.get('bdgg_private_message_notifications')) {
-                        var memes = {
-                            body: data.nick + " sent you a private message. Click here to view the chat!",
-                            icon: destiny.cdn + '/chat/img/notifyicon.png'
-                        };
-                        if (Notification.permission === 'granted'){
-                            notif = new Notification("Better Better Destiny.GG", memes);
-                            notif.onclick = function() { 
-                                window.focus();
-                                notif.close();
-                                if ($(".mark-as-read")) {
-                                    $(".mark-as-read").click();
-                                }
+                    if (ignoreArray.indexOf(data.nick.toLowerCase()) !== -1) {
+
+                        if (bdgg.settings.get('bdgg_private_message_notifications')) {
+                            console.error("wew");
+                            var memes = {
+                                body: data.nick + " sent you a private message. Click here to view the chat!",
+                                icon: destiny.cdn + '/chat/img/notifyicon.png'
                             };
-                            setTimeout(function(){ notif.close(); }, 5000);
-                        } 
+                            if (Notification.permission === 'granted'){
+                                notif = new Notification("Better Better Destiny.GG", memes);
+                                notif.onclick = function() { 
+                                    window.focus();
+                                    notif.close();
+                                    if ($(".mark-as-read")) {
+                                        $(".mark-as-read").click();
+                                    }
+                                };
+                                setTimeout(function(){ notif.close(); }, 5000);
+                            } 
+                        }
                     }
                     return bdggPRIVMSG;
                 };

--- a/betterdgg/modules/notification.js
+++ b/betterdgg/modules/notification.js
@@ -15,12 +15,13 @@
                     var ignoreArray = ignoreList.toLowerCase().split(' ').join('').split(',');
                     console.error(ignoreList);
                     console.error(ignoreArray);
+                    console.error(data.nick);
 
 
 
                     var bdggPRIVMSG = fnChatPRIVMSG.apply(this, arguments);
                     var notif;
-                    if (ignoreArray.indexOf(data.nick.toLowerCase()) !== -1) {
+                    if (ignoreArray.indexOf(data.nick.toLowerCase()) === -1) {
 
                         if (bdgg.settings.get('bdgg_private_message_notifications')) {
                             console.error("wew");

--- a/betterdgg/modules/notification.js
+++ b/betterdgg/modules/notification.js
@@ -12,19 +12,14 @@
                 var fnChatPRIVMSG = destiny.chat.onPRIVMSG;
                 var bdggChatPRIVMSG = function(data) {
                     var ignoreList = bdgg.settings.get('bdgg_user_ignore');
-                    var ignoreArray = ignoreList.toLowerCase().split(' ').join('').split(',');
-                    console.error(ignoreList);
-                    console.error(ignoreArray);
-                    console.error(data.nick);
-
-
-
+                    if (ignoreList !== "") {
+                        var ignoreArray = ignoreList.toLowerCase().split(' ').join('').split(',');
+                    }
                     var bdggPRIVMSG = fnChatPRIVMSG.apply(this, arguments);
                     var notif;
                     if (ignoreArray.indexOf(data.nick.toLowerCase()) === -1) {
 
                         if (bdgg.settings.get('bdgg_private_message_notifications')) {
-                            console.error("wew");
                             var memes = {
                                 body: data.nick + " sent you a private message. Click here to view the chat!",
                                 icon: destiny.cdn + '/chat/img/notifyicon.png'


### PR DESCRIPTION
This prevents the PM notif being shown if a user receives a PM from someone they have ignored, it was requested by someone ages ago but I can't remember who :100: 
Discalimer: I will stop with the autism commits soon, I swear SWEATSTINY
