### PR TITLE
Made some changes to make this work on safari.

### DIFF
--- a/betterdgg/betterdgg.css
+++ b/betterdgg/betterdgg.css
@@ -2,14 +2,14 @@
     background-image:url('images/emoticons/CoolCat.png');
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-NOBULLY, .chat-emote.bdgg-chat-emote-NOBULLY {
     background-image:url('images/emoticons/NOBULLY.png');
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-NOBULLY:hover, .bdgg-chat-emote-NOBULLY:hover {
@@ -21,56 +21,56 @@
     background-image:url('images/emoticons/gachiGASM.png');
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-NotLikeThis, .chat-emote.bdgg-chat-emote-NotLikeThis {
     background-image:url('images/emoticons/NotLikeThis.png');
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-haHAA, .chat-emote.bdgg-chat-emote-haHAA {
     background-image:url('images/emoticons/haHAA.png');
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-FeelsAmazingMan, .chat-emote.bdgg-chat-emote-FeelsAmazingMan {
     background-image:url('images/emoticons/FeelsAmazingMan.png');
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-OhMyDog, .chat-emote.bdgg-chat-emote-OhMyDog {
     background-image:url('images/emoticons/OhMyDog.png');
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-FeelsBadMan, .chat-emote.bdgg-chat-emote-FeelsBadMan {
     background-image:url('images/emoticons/FeelsBadMan.png');
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-FeelsGoodMan, .chat-emote.bdgg-chat-emote-FeelsGoodMan {
     background-image:url('images/emoticons/FeelsGoodMan.png');
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-MingLee, .chat-emote.bdgg-chat-emote-MingLee {
     background-image:url('images/emoticons/MingLee.png');
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-OuO, .chat-emote.bdgg-chat-emote-OuO {
@@ -89,21 +89,21 @@
     background-image:url('images/emoticons/KappaPride.png');
     width: 22px;
     height: 31px;
-    margin-top: -31px;
+    margin-top: -31px !important;
 }
 
 .chat-emote.chat-emote-DESBRO, .chat-emote.bdgg-chat-emote-DESBRO {
     background-image:url('images/emoticons/DESBRO.png');
     width: 27px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-TooSpicy, .chat-emote.bdgg-chat-emote-TooSpicy {
     background-image:url('images/emoticons/TooSpicy.png');
     width: 23px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
 }
 
 .chat-emote-SoSad.bdgg-chat-emote-override {
@@ -151,91 +151,91 @@
 .chat-emote-CARBUCKS, .chat-emote.bdgg-chat-emote-CARBUCKS {
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/CARBUCKS.png');
 }
 
 .chat-emote-ChanChamp, .chat-emote.bdgg-chat-emote-ChanChamp {
     width: 23px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/ChanChamp.png');
 }
 
 .chat-emote-Depresstiny, .chat-emote.bdgg-chat-emote-Depresstiny {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/Depresstiny.png');
 }
 
 .chat-emote-HerbPerve, .chat-emote.bdgg-chat-emote-HerbPerve {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/HerbPerve.png');
 }
 
 .chat-emote-Jewstiny, .chat-emote.bdgg-chat-emote-Jewstiny {
     width: 27px;
     height: 32px;
-    margin-top: -32px;
+    margin-top: -32px !important;
     background: url('images/emoticons/Jewstiny.png');
 }
 
 .chat-emote-NiceMeMe, .chat-emote.bdgg-chat-emote-NiceMeMe {
     width: 27px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/NiceMeMe.png');
 }
 
 .chat-emote-CallHafu, .chat-emote.bdgg-chat-emote-CallHafu {
     width: 36px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/CallHafu.png');
 }
 
 .chat-emote-ChibiDesti, .chat-emote.bdgg-chat-emote-ChibiDesti {
     width: 40px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/ChibiDesti.png');
 }
 
 .chat-emote-CORAL, .chat-emote.bdgg-chat-emote-CORAL {
     width: 25px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/CORAL.png');
 }
 
 .chat-emote-CUX, .chat-emote.bdgg-chat-emote-CUX {
     width: 76px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/CUX.png');
 }
 
 .chat-emote-DSPstiny, .chat-emote.bdgg-chat-emote-DSPstiny {
     width: 22px;
     height: 32px;
-    margin-top: -32px;
+    margin-top: -32px !important;
     background: url('images/emoticons/DSPstiny.png');
 }
 
 .chat-emote-GabeN, .chat-emote.bdgg-chat-emote-GabeN {
     width: 27px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/GabeN.png');
 }
 
 .chat-emote-ITSRAWWW, .chat-emote.bdgg-chat-emote-ITSRAWWW {
     width: 25px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/ITSRAWWW.png');
 	animation: ITSRAWWW 100ms 7
 }
@@ -243,7 +243,7 @@
 .chat-emote-ITSRAWWW, .chat-emote.bdgg-chat-emote-ITSRAWWW:hover {
     width: 25px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/ITSRAWWW.png');
 	animation: ITSRAWWW-hover 100ms infinite
 }
@@ -278,203 +278,203 @@
 .chat-emote-RaveDoge, .chat-emote.bdgg-chat-emote-RaveDoge {
     width: 44px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/RaveDoge.gif');
 }
 
 .chat-emote-CuckCrab, .chat-emote.bdgg-chat-emote-CuckCrab {
     width: 32px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/CuckCrab.gif');
 }
 
 .chat-emote-Riperino, .chat-emote.bdgg-chat-emote-Riperino {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/Riperino.png');
 }
 
 .chat-emote-SephURR, .chat-emote.bdgg-chat-emote-SephURR {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/SephURR.png');
 }
 
 .chat-emote-ShibeZ, .chat-emote.bdgg-chat-emote-ShibeZ {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/ShibeZ.png');
 }
 
 .chat-emote-SourPls, .chat-emote.bdgg-chat-emote-SourPls {
     width: 32px;
     height: 32px;
-    margin-top: -32px;
+    margin-top: -32px !important;
     background: url('images/emoticons/SourPls.gif');
 }
 
 .chat-emote-SuccesS, .chat-emote.bdgg-chat-emote-SuccesS {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/SuccesS.png');
 }
 
 .chat-emote-TopCake, .chat-emote.bdgg-chat-emote-TopCake {
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/TopCake.png');
 }
 
 .chat-emote-WEOW, .chat-emote.bdgg-chat-emote-WEOW {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/WEOW.png');
 }
 
 .chat-emote-4Head, .chat-emote.bdgg-chat-emote-4Head {
     width: 20px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/emoticons.png') no-repeat -242px -123px;
 }
 
 .chat-emote-AlisherZ, .chat-emote.bdgg-chat-emote-AlisherZ {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/AlisherZ.png');
 }
 
 .chat-emote-BabyRage, .chat-emote.bdgg-chat-emote-BabyRage {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/BabyRage.png');
 }
 
 .chat-emote-D\:, .chat-emote.bdgg-chat-emote-D_ {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/D_.png');
 }
 
 .chat-emote-DansGame, .chat-emote.bdgg-chat-emote-DansGame {
     width: 24px;
     height: 31px;
-    margin-top: -31px;
+    margin-top: -31px !important;
     background: url('images/emoticons/DansGame.png');
 }
 
 .chat-emote-dayJoy, .chat-emote.bdgg-chat-emote-dayJoy {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/dayJoy.png');
 }
 
 .chat-emote-DatSheffy, .chat-emote.bdgg-chat-emote-DatSheffy {
     width: 24px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/emoticons.png') no-repeat -131px -90px;
 }
 
 .chat-emote-EleGiggle, .chat-emote.bdgg-chat-emote-EleGiggle {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/EleGiggle.png');
 }
 
 .chat-emote-kaceyFace, .chat-emote.bdgg-chat-emote-kaceyFace {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/kaceyFace.png');
 }
 
 .chat-emote-Keepo, .chat-emote.bdgg-chat-emote-Keepo {
     width: 27px;
     height: 29px;
-    margin-top: -29px;
+    margin-top: -29px !important;
     background: url('images/emoticons/Keepo.png');
 }
 
 .chat-emote-Kreygasm, .chat-emote.bdgg-chat-emote-Kreygasm {
     width: 19px;
     height: 27px;
-    margin-top: -27px;
+    margin-top: -27px !important;
     background: url('images/emoticons/emoticons.png') no-repeat -141px 0;
 }
 
 .chat-emote-lirikThump, .chat-emote.bdgg-chat-emote-lirikThump {
     width: 28px;
     height: 26px;
-    margin-top: -26px;
+    margin-top: -26px !important;
     background: url('images/emoticons/lirikThump.png');
 }
 
 .chat-emote-OpieOP, .chat-emote.bdgg-chat-emote-OpieOP {
     width: 21px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/emoticons.png') no-repeat -179px -123px;
 }
 
 .chat-emote-PJSalt, .chat-emote.bdgg-chat-emote-PJSalt {
     width: 36px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/emoticons.png') no-repeat -106px -123px;
 }
 
 .chat-emote-PogChamp, .chat-emote.bdgg-chat-emote-PogChamp {
     width: 23px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/emoticons.png') no-repeat -166px -28px;
 }
 
 .chat-emote-ResidentSleeper, .chat-emote.bdgg-chat-emote-ResidentSleeper {
     width: 28px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/emoticons.png') no-repeat -212px -28px;
 }
 
 .chat-emote-SMOrc, .chat-emote.bdgg-chat-emote-SMOrc {
     width: 32px;
     height: 32px;
-    margin-top: -32px;
+    margin-top: -32px !important;
     background: url('images/emoticons/emoticons.png') no-repeat -25px -123px;
 }
 
 .chat-emote-SSSsss, .chat-emote.bdgg-chat-emote-SSSsss {
     width: 24px;
     height: 24px;
-    margin-top: -24px;
+    margin-top: -24px !important;
     background: url('images/emoticons/emoticons.png') no-repeat -239px 0;
 }
 
 .chat-emote-SwiftRage, .chat-emote.bdgg-chat-emote-SwiftRage {
     width: 21px;
     height: 28px;
-    margin-top: -28px;
+    margin-top: -28px !important;
     background: url('images/emoticons/emoticons.png') no-repeat -241px -28px;
 }
 
 .chat-emote-WinWaker, .chat-emote.bdgg-chat-emote-WinWaker {
     width: 30px;
     height: 30px;
-    margin-top: -30px;
+    margin-top: -30px !important;
     background: url('images/emoticons/emoticons.png') no-repeat -23px -59px;
 }
 

--- a/betterdgg/content-scripts/stalk.js
+++ b/betterdgg/content-scripts/stalk.js
@@ -3,6 +3,8 @@ var port = null;
 if (typeof chrome !== "undefined" && chrome.runtime) {
     port = chrome.runtime.connect();
     port.onMessage.addListener(pushMessage);
+} else if (navigator.userAgent.indexOf('Safari') !== -1) {
+    // someone who knows this project more intimately can figure this out  
 } else if (typeof self !== "undefined" && self.postMessage) {
     self.on("message", pushMessage);
 }

--- a/betterdgg/modules/namecolor.js
+++ b/betterdgg/modules/namecolor.js
@@ -42,10 +42,10 @@
             tagUpdate: function() {
                 var nameColorKeys = [];
                 var jNameColor = getNameColor();
-                let res = '';
+                var res = '';
                 for(var k in jNameColor) nameColorKeys.push(k);
                 document.querySelector('#bdgg_name_color').value = JSON.stringify(jNameColor);
-                for (let i = 0; i < nameColorKeys.length; i++) {
+                for (var i = 0; i < nameColorKeys.length; i++) {
                     res += this.userTemplate.replace('{}', nameColorKeys[i]) + this.colorTemplate.replace('{}', jNameColor[nameColorKeys[i]]);
                 }
                 if (this.style.styleSheet)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -188,8 +188,7 @@ gulp.task('safari', [ 'safari:css', 'safari:plist', 'js' ], function() {
     var js = gulp.src([ './build/betterdgg.js', './safari/inject.js', './build/content.js' ])
         .pipe(concat('betterdgg.js'))
         .pipe(gulp.dest('./dist/betterdgg.safariextension/'));
-    merge(assets, js).on('end', function() {
-        console.log('Open ./dist/betterdgg.safariextension in Safari Extension Builder'
-            + ' to dist Safari extension');
-    });
+    merge(assets, js);
+    console.log('Open ./dist/betterdgg.safariextension in Safari Extension Builder'
+                + ' to dist Safari extension');
 });

--- a/safari/Info.plist
+++ b/safari/Info.plist
@@ -44,7 +44,9 @@
 			<array>
 				<string>*.destiny.gg</string>
 			</array>
-			<key>Level</key>
+                        <key>Include Secure Pages</key>
+                        <true/>
+                        <key>Level</key>
 			<string>Some</string>
 		</dict>
 	</dict>

--- a/safari/Info.plist
+++ b/safari/Info.plist
@@ -44,9 +44,9 @@
 			<array>
 				<string>*.destiny.gg</string>
 			</array>
-                        <key>Include Secure Pages</key>
-                        <true/>
-                        <key>Level</key>
+			<key>Include Secure Pages</key>
+			<true/>
+			<key>Level</key>
 			<string>Some</string>
 		</dict>
 	</dict>


### PR DESCRIPTION
Been using safari lately and realized that this exists but doesn't work.

SweetieBelle's namecolor module uses `let`, which does not seem to be implemented in Safari 9.*, and doesn't seem to have any apparent use in this case (I don't see anywhere that the hoisting would hurt anything).

I don't know the d.gg/bdgg codebase well enough to know what's going on with stalk.js.  `self.on()` errors, telling me that self has no function `on()`.  `Window.on()` works (these are synonymous, right?), but I get console errors at `window.postMessage(obj, '*');` and `self.postMessage(obj)` with "An invalid or illegal string was specified.".  I don't know what object is being passed into these and didn't look too much into it, because the rest of the extension works.

Finally, the callback explaining how to install it never fires for some reason.  I would assume that if the merge fails, execution stops anyway.

I may have a signing certificate for you too.